### PR TITLE
feature/media-and-media-loader

### DIFF
--- a/docs/src/Media/stories.js
+++ b/docs/src/Media/stories.js
@@ -27,7 +27,7 @@ export default {
     component: {
       control: {
         type: 'select',
-        options: ['div', 'video', 'audio', 'picture', 'iframe', 'img'],
+        options: ['video', 'audio', 'picture', 'iframe', 'img'],
       },
     },
     src: {
@@ -43,17 +43,16 @@ const Template = (args) => <Media {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
-  component: 'div',
+  component: 'img',
   src: sources.jpg.xs,
-  alt: '',
-  style: { minHeight: 100 },
+  alt: 'Image description',
 }
 
 export const Picture = Template.bind({})
 Picture.args = {
   component: 'picture',
   breakpoints: sources.jpg,
-  alt: '',
+  alt: 'Image description',
 }
 
 export const PictureMultiFormat = Template.bind({})
@@ -63,7 +62,7 @@ PictureMultiFormat.args = {
     xs: [{ src: sources.webp.xs, type: 'image/webp' }, { src: sources.jpg.xs }],
     sm: [{ src: sources.webp.sm, type: 'image/webp' }, { src: sources.jpg.sm }],
   },
-  alt: '',
+  alt: 'Image description',
 }
 
 export const Audio = Template.bind({})
@@ -92,7 +91,7 @@ Custom.args = {
     xs: {
       component: 'img',
       src: sources.jpg.xs,
-      alt: 'Just another image description',
+      alt: 'Image description',
     },
     sm: {
       component: 'video',
@@ -101,4 +100,14 @@ Custom.args = {
       muted: true,
     },
   },
+}
+
+export const Lazy = Template.bind({})
+Lazy.args = {
+  component: 'img',
+  src: sources.jpg.xs,
+  alt: 'Image description',
+  loading: 'lazy',
+  rootMargin: '0% 0% -50%',
+  style: { margin: '200vh 0' },
 }

--- a/docs/src/MediaLoader/stories.js
+++ b/docs/src/MediaLoader/stories.js
@@ -23,12 +23,6 @@ const sources = {
 export default {
   title: 'Components/MediaLoader',
   component: MediaLoader,
-  argTypes: {
-    onLoaded: { action: 'onLoaded' },
-    onEnter: { action: 'onEnter' },
-    onEntering: { action: 'onEntering' },
-    onEntered: { action: 'onEntered' },
-  },
 }
 
 // eslint-disable-next-line react/prop-types
@@ -74,7 +68,7 @@ export const Controlled = Template.bind({})
 Controlled.args = {
   width: 16,
   height: 9,
-  reveal: false,
+  in: false,
   mediaProps: {
     component: 'img',
     src: sources.responsive.xl,
@@ -119,21 +113,8 @@ export const TransitionInDistanceThreshold = Template.bind({})
 TransitionInDistanceThreshold.args = {
   width: 16,
   height: 9,
-  style: { marginTop: '150vh' },
-  revealRootMargin: '0% 0% -50%',
-  mediaProps: {
-    component: 'img',
-    src: sources.replace.full,
-  },
-}
-
-export const LazyWithLoadInDistanceThreshold = Template.bind({})
-LazyWithLoadInDistanceThreshold.args = {
-  width: 16,
-  height: 9,
-  style: { marginTop: '150vh' },
-  lazyRootMargin: '0% 0% -50%',
-  lazy: true,
+  style: { margin: '150vh 0' },
+  rootMargin: '0% 0% -50%',
   mediaProps: {
     component: 'img',
     src: sources.replace.full,

--- a/packages/oui/src/Media/MediaSources.js
+++ b/packages/oui/src/Media/MediaSources.js
@@ -6,7 +6,7 @@ import useTheme from '@material-ui/core/styles/useTheme'
  * @ignore - internal component.
  */
 function MediaSources(props) {
-  const { breakpoints, ...other } = props
+  const { breakpoints, lazy } = props
 
   const theme = useTheme()
   const keys = [...theme.breakpoints.keys].reverse()
@@ -21,11 +21,11 @@ function MediaSources(props) {
     }
 
     if (typeof breakpoint === 'string') {
-      return <source key={key} media={media} srcSet={breakpoint} {...other} />
+      return <source key={key} media={media} srcSet={!lazy ? breakpoint : undefined} />
     }
 
     return breakpoint.map(({ src, type }) => (
-      <source key={key + type} media={media} srcSet={src} type={type} {...other} />
+      <source key={key + type} media={media} srcSet={!lazy ? src : undefined} type={type} />
     ))
   })
 }
@@ -43,6 +43,7 @@ MediaSources.propTypes = {
     lg: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(sourceType)]),
     xl: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(sourceType)]),
   }).isRequired,
+  lazy: PropTypes.bool,
 }
 
 export default MediaSources

--- a/packages/oui/src/Media/MediaWithWidth.js
+++ b/packages/oui/src/Media/MediaWithWidth.js
@@ -1,20 +1,20 @@
-// @inheritedComponent CardMedia
+// @inheritedComponent MediaBase
 
 import * as React from 'react'
 import PropTypes from 'prop-types'
 import useTheme from '@material-ui/core/styles/useTheme'
-import CardMedia from '@material-ui/core/CardMedia'
 import useMediaQuery from '@material-ui/core/useMediaQuery'
+import MediaBase from '../MediaBase'
 
 /**
  * @ignore - internal component.
  */
 const MediaWithWidth = React.forwardRef(function MediaWithWidth(props, ref) {
-  const { breakpoints, component, ...other } = props
+  const { breakpoints, ...other } = props
 
   const theme = useTheme()
   const keys = [...theme.breakpoints.keys].reverse()
-  const breakpoint = keys.reduce((output, key) => {
+  const src = keys.reduce((output, key) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const matches = useMediaQuery(theme.breakpoints.up(key))
     return !output && matches ? breakpoints[key] : output
@@ -27,13 +27,13 @@ const MediaWithWidth = React.forwardRef(function MediaWithWidth(props, ref) {
   //
   // An alternative is to implement a `ssrMatchMedia`.
   // https://material-ui.com/components/use-media-query/#server-side-rendering
-  if (breakpoint === null) {
+  if (src === null) {
     return null
   }
 
-  const { src, ...more } = typeof breakpoint !== 'object' ? { src: breakpoint } : breakpoint
+  const componentProps = typeof src !== 'object' ? { src } : src
 
-  return <CardMedia component={component} image={src} ref={ref} {...more} {...other} />
+  return <MediaBase ref={ref} {...componentProps} {...other} />
 })
 
 MediaWithWidth.propTypes = {
@@ -44,7 +44,6 @@ MediaWithWidth.propTypes = {
     lg: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     xl: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   }),
-  component: PropTypes.elementType,
 }
 
 export default MediaWithWidth

--- a/packages/oui/src/MediaBase/MediaBase.js
+++ b/packages/oui/src/MediaBase/MediaBase.js
@@ -1,0 +1,64 @@
+import * as React from 'react'
+import PropTypes from 'prop-types'
+import classnames from 'clsx'
+import { chainPropTypes } from '@material-ui/utils'
+import withStyles from '@material-ui/core/styles/withStyles'
+
+export const styles = {
+  root: {
+    display: 'block',
+    width: '100%',
+  },
+  cover: {
+    // ⚠️ object-fit is not supported by IE 11.
+    objectFit: 'cover',
+  },
+  picture: {
+    '& img': {
+      display: 'inherit',
+      width: 'inherit',
+      height: 'inherit',
+      objectFit: 'inherit',
+    },
+  },
+}
+
+const MediaBase = React.forwardRef(function MediaBase(props, ref) {
+  const { children, classes, className, component: Component = 'img', lazy, src, ...other } = props
+
+  return (
+    <Component
+      className={classnames(
+        classes.root,
+        {
+          [classes.cover]: ['video', 'picture', 'img'].includes(Component),
+          [classes.picture]: ['picture'].includes(Component),
+        },
+        className,
+      )}
+      src={!lazy ? src : undefined}
+      ref={ref}
+      {...other}
+    >
+      {children}
+    </Component>
+  )
+})
+
+MediaBase.propTypes = {
+  children: chainPropTypes(PropTypes.node, (props) => {
+    if (!props.children && !props.src && !props.component) {
+      return new Error(
+        'Oakwood-UI: Either `children`, `src` or `component` prop must be specified.',
+      )
+    }
+    return null
+  }),
+  classes: PropTypes.object,
+  className: PropTypes.string,
+  component: PropTypes.elementType,
+  lazy: PropTypes.bool,
+  src: PropTypes.string,
+}
+
+export default withStyles(styles, { name: 'OuiMediaBase' })(MediaBase)

--- a/packages/oui/src/MediaBase/index.js
+++ b/packages/oui/src/MediaBase/index.js
@@ -1,0 +1,1 @@
+export { default } from './MediaBase'


### PR DESCRIPTION
[MediaBase] Add custom MediaBase component replacing Mui CardMedia.
[Media] Compose with new MediaBase instead of Mui CardMedia.
[Media] Drop support for `component="div"`.
[Media] Add functionality for lazy loading via native interface `loading="lazy"`.
[MediaLoader] Remove functionality for lazy loading (moved to Media).
[docs] Update affected component stories.